### PR TITLE
Add include<stdint.h>

### DIFF
--- a/src/tifffastcrop.c
+++ b/src/tifffastcrop.c
@@ -17,6 +17,7 @@
 #include <stdlib.h> /* exit, strtoul */
 #include <string.h>
 #include <strings.h> /* strncasecmp */
+#include <stdint.h>
 #include <ctype.h> /* isdigit */
 #include <assert.h>
 #include <errno.h>

--- a/src/tiffmakemosaic.c
+++ b/src/tiffmakemosaic.c
@@ -18,6 +18,7 @@
 #include <stdlib.h> /* exit, strtoul */
 #include <string.h>
 #include <strings.h> /* strncasecmp */
+#include <stdint.h>
 #include <assert.h>
 #include <errno.h>
 #include <tiff.h>

--- a/src/tiffsplittiles.c
+++ b/src/tiffsplittiles.c
@@ -14,6 +14,7 @@
 #include <stdio.h>
 #include <stdlib.h> /* exit */
 #include <string.h>
+#include <stdint.h>
 #include <tiff.h>
 #include <tiffio.h>
 


### PR DESCRIPTION
Add `#include<stdint.h>` to each .c file

<details><summary> error on make </summary>

Run `make` after execution `./configure` on `debian:bullseye-slim`

```
root@34a648623bb5:~/largetifftools-1.4.1# make 
make  all-recursive
make[1]: Entering directory '/root/largetifftools-1.4.1'
Making all in src
make[2]: Entering directory '/root/largetifftools-1.4.1/src'
gcc -DHAVE_CONFIG_H -I. -I..     -g -O2 -fopenmp -MT tiffsplittiles.o -MD -MP -MF .deps/tiffsplittiles.Tpo -c -o tiffsplittiles.o tiffsplittiles.c
tiffsplittiles.c:57:33: error: unknown type name 'uint32_t'; did you mean 'u_int32_t'?
   57 | static int searchNumberOfDigits(uint32_t u)
      |                                 ^~~~~~~~
      |                                 u_int32_t
tiffsplittiles.c: In function 'copyOtherFields':
tiffsplittiles.c:89:3: error: unknown type name 'uint16_t'; did you mean 'u_int16_t'?
   89 |   uint16_t bitspersample, samplesperpixel, shortv, *shortav;
      |   ^~~~~~~~
      |   u_int16_t
tiffsplittiles.c:92:3: error: unknown type name 'uint32_t'; did you mean 'u_int32_t'?
   92 |   uint32_t longv;
      |   ^~~~~~~~
      |   u_int32_t
tiffsplittiles.c:117:5: error: unknown type name 'uint16_t'; did you mean 'u_int16_t'?
  117 |   { uint16_t *red, *green, *blue;
      |     ^~~~~~~~
      |     u_int16_t
tiffsplittiles.c:120:5: error: unknown type name 'uint16_t'; did you mean 'u_int16_t'?
  120 |   { uint16_t shortv2;
      |     ^~~~~~~~
      |     u_int16_t
tiffsplittiles.c: In function 'main':
tiffsplittiles.c:180:1: error: unknown type name 'uint32_t'; did you mean 'u_int32_t'?
  180 | uint32_t imagewidth, imagelength;
      | ^~~~~~~~
      | u_int32_t
tiffsplittiles.c:181:1: error: unknown type name 'uint32_t'; did you mean 'u_int32_t'?
  181 | uint32_t tilewidth, tilelength;
      | ^~~~~~~~
      | u_int32_t
tiffsplittiles.c:182:1: error: unknown type name 'uint32_t'; did you mean 'u_int32_t'?
  182 | uint32_t x, y;
      | ^~~~~~~~
      | u_int32_t
tiffsplittiles.c:183:1: error: unknown type name 'uint32_t'; did you mean 'u_int32_t'?
  183 | uint32_t imagedepth;
      | ^~~~~~~~
      | u_int32_t
tiffsplittiles.c:184:1: error: unknown type name 'uint16_t'; did you mean 'u_int16_t'?
  184 | uint16_t planarconfig, compression;
      | ^~~~~~~~
      | u_int16_t
tiffsplittiles.c:270:3: warning: implicit declaration of function 'searchNumberOfDigits' [-Wimplicit-function-declaration]
  270 |   searchNumberOfDigits((imagewidth+tilewidth-1)/tilewidth);
      |   ^~~~~~~~~~~~~~~~~~~~
tiffsplittiles.c:282:3: error: unknown type name 'uint32_t'; did you mean 'u_int32_t'?
  282 |   uint32_t outputimageslength= tilelength;
      |   ^~~~~~~~
      |   u_int32_t
tiffsplittiles.c:294:5: error: unknown type name 'uint32_t'; did you mean 'u_int32_t'?
  294 |     uint32_t tilenumber= TIFFComputeTile(in, x, y, 0, 0);
      |     ^~~~~~~~
      |     u_int32_t
tiffsplittiles.c:295:5: error: unknown type name 'uint32_t'; did you mean 'u_int32_t'?
  295 |     uint32_t outputimagewidth= tilewidth;
      |     ^~~~~~~~
      |     u_int32_t
tiffsplittiles.c:334:7: error: unknown type name 'uint32_t'; did you mean 'u_int32_t'?
  334 |       uint32_t count = 0;
      |       ^~~~~~~~
      |       u_int32_t
tiffsplittiles.c:336:7: error: unknown type name 'uint16_t'; did you mean 'u_int16_t'?
  336 |       uint16_t subsamplinghor, subsamplingver;
      |       ^~~~~~~~
      |       u_int16_t
make[2]: *** [Makefile:376: tiffsplittiles.o] Error 1
make[2]: Leaving directory '/root/largetifftools-1.4.1/src'
make[1]: *** [Makefile:361: all-recursive] Error 1
make[1]: Leaving directory '/root/largetifftools-1.4.1'
make: *** [Makefile:302: all] Error 2
```

</details>
